### PR TITLE
Removed 'flex-wrap' from Contribue ETH box

### DIFF
--- a/webapp/style/style.css
+++ b/webapp/style/style.css
@@ -446,7 +446,7 @@ p {
 .btn-group {
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
+    /*! flex-wrap: wrap; */
 }
 
 


### PR DESCRIPTION
Removed 'flex-wrap' for the purple 'Contribute ETH' box to make it compatible with iPhones other other mobile devices. The 'Take the Lead' box (within Contribute ETH box) was getting pushed to another line on my iPhone and it looked strange.